### PR TITLE
Use relative path to files instead of absolute to fix issue with dynamic dir path on iOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,10 +11,10 @@ PODS:
   - Firebase/Crashlytics (10.9.0):
     - Firebase/CoreOnly
     - FirebaseCrashlytics (~> 10.9.0)
-  - firebase_core (2.13.0):
+  - firebase_core (2.13.1):
     - Firebase/CoreOnly (= 10.9.0)
     - Flutter
-  - firebase_crashlytics (3.3.1):
+  - firebase_crashlytics (3.3.2):
     - Firebase/Crashlytics (= 10.9.0)
     - firebase_core
     - Flutter
@@ -146,8 +146,8 @@ SPEC CHECKSUMS:
   ffmpeg-kit-ios-full-gpl: 2682965e5b3e7f13a05836d46d302eafe6c5039e
   ffmpeg_kit_flutter_full_gpl: 7dcfcdc419f4667252cde1871859976bca328169
   Firebase: bd152f0f3d278c4060c5c71359db08ebcfd5a3e2
-  firebase_core: fc68c0f9eec4e800b9418deff14a7e0a504016f3
-  firebase_crashlytics: 6c82b5f80f225b2429ebc5fdadde5b7e7735ed4e
+  firebase_core: ce64b0941c6d87c6ef5022ae9116a158236c8c94
+  firebase_crashlytics: 9b80d1944507cc07fa1c4455797f7d2eb7c8873f
   FirebaseCore: b68d3616526ec02e4d155166bbafb8eca64af557
   FirebaseCoreExtension: 8d93ebbf6838a874b4ed82a564c9d6705f8365dd
   FirebaseCoreInternal: 971029061d326000d65bfdc21f5502c75c8b0893

--- a/lib/creation/creation.dart
+++ b/lib/creation/creation.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: library_private_types_in_public_api
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:image_picker/image_picker.dart';
@@ -8,7 +10,6 @@ import 'package:slidemix/creation/creation_bloc.dart';
 import 'package:slidemix/creation/widget/creation_cancel_dialog.dart';
 import 'package:slidemix/creation/widget/creation_leave_dialog.dart';
 import 'package:slidemix/creation/widget/creation_source_dialog.dart';
-import 'package:slidemix/creation/data/media.dart';
 import 'package:slidemix/creation/widget/creation_list.dart';
 import 'package:slidemix/localizations.dart';
 import 'package:slidemix/logger.dart';
@@ -60,19 +61,19 @@ class _CreationScreenState extends State<CreationScreen> {
   }
 
   Future _pickMedia() async {
-    List<Media> media = [];
+    List<File> files = [];
 
     switch (await PickMediaSourceDialog.show(context)) {
       case CreationMediaSource.camera:
         final image = await ImagePicker().pickImage(source: ImageSource.camera);
         if (!mounted || image == null) return;
-        media.add(Media(image.path));
+        files.add(File(image.path));
         break;
 
       case CreationMediaSource.gallery:
         final images = await ImagePicker().pickMultiImage();
         if (!mounted || images.isEmpty) return;
-        media.addAll(images.map((image) => Media(image.path)));
+        files.addAll(images.map((image) => File(image.path)));
         break;
 
       default:
@@ -80,7 +81,7 @@ class _CreationScreenState extends State<CreationScreen> {
     }
 
     if (!mounted) return;
-    BlocProvider.of<CreationBloc>(context).pickMedia(media);
+    BlocProvider.of<CreationBloc>(context).pickFiles(files);
   }
 
   @override

--- a/lib/creation/creation_bloc.dart
+++ b/lib/creation/creation_bloc.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
@@ -47,28 +48,29 @@ class CreationBloc extends Bloc<dynamic, CreationState> {
     return super.close();
   }
 
-  FutureOr<void> openDraft(Movie draftMovie) async {
+  Future<void> openDraft(Movie draftMovie) async {
     __project = await _movieCreator.openDraft(draftMovie);
     emit(state.copyWith(
       media: __project?.media,
     ));
   }
 
-  FutureOr<void> pickMedia(List<Media> media) async {
+  Future<void> pickFiles(List<File> files) async {
     final project = await _project;
+    final media = files.map((file) => Media(projectId: project.id, path: file.path));
     emit(state.copyWith(
       media: await project.attachMedia(media),
     ));
   }
 
-  FutureOr<void> deleteMedia(Media media) async {
+  Future<void> deleteMedia(Media media) async {
     final project = await _project;
     emit(state.copyWith(
       media: await project.deleteMedia(media),
     ));
   }
 
-  FutureOr<Route<void>> reset({required bool deleteDraft}) async {
+  Future<Route<void>> reset({required bool deleteDraft}) async {
     await (await _project).dispose(deleteDraft: deleteDraft);
     __project = null;
 
@@ -84,7 +86,7 @@ class CreationBloc extends Bloc<dynamic, CreationState> {
     }
   }
 
-  FutureOr<Movie> createMovie() async {
+  Future<Movie> createMovie() async {
     Logger.d('createMovie ${state.media}');
     emit(state.copyWith(isLoading: true));
 

--- a/lib/creation/data/media.dart
+++ b/lib/creation/data/media.dart
@@ -1,12 +1,16 @@
 import 'package:equatable/equatable.dart';
 
 class Media extends Equatable {
+  final int projectId;
   final String path;
 
-  const Media(this.path);
+  const Media({
+    required this.projectId,
+    required this.path,
+  });
 
   @override
-  List<Object?> get props => [path];
+  List<Object?> get props => [projectId, path];
 
   @override
   bool? get stringify => true;

--- a/lib/creation/widget/creation_card.dart
+++ b/lib/creation/widget/creation_card.dart
@@ -1,8 +1,7 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:slidemix/colors.dart';
 import 'package:slidemix/creation/data/media.dart';
+import 'package:slidemix/file_manager.dart';
 
 class AddMediaCardWidget extends StatelessWidget {
   final VoidCallback onTap;
@@ -62,8 +61,9 @@ class MediaCreationCard extends StatelessWidget {
             child: AspectRatio(
               aspectRatio: 1,
               child: Image.file(
-                File(media.path),
+                FileManager.of(context).getThumbFromDraftMedia(media),
                 fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
               ),
             ),
           ),

--- a/lib/creator/movie_creator.dart
+++ b/lib/creator/movie_creator.dart
@@ -4,6 +4,7 @@ import 'package:slidemix/creator/movie_project.dart';
 import 'package:slidemix/creator/project_id_provider.dart';
 import 'package:slidemix/creator/slideshow_creator.dart';
 import 'package:slidemix/draft/draft_movie_manager.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/logger.dart';
 import 'package:slidemix/movies/data/movie.dart';
 import 'package:slidemix/movies/data/movie_dao.dart';
@@ -18,12 +19,14 @@ abstract class MovieCreator {
 
 class MovieCreatorImpl extends MovieCreator {
   final DraftMovieManager draftMovieManager;
+  final FileManager fileManager;
   final MovieDao movieDao;
   final ProjectIdProvider projectIdProvider;
   final SlideShowCreator slideShowCreator;
 
   MovieCreatorImpl({
     required this.draftMovieManager,
+    required this.fileManager,
     required this.movieDao,
     required this.projectIdProvider,
     required this.slideShowCreator,
@@ -35,6 +38,7 @@ class MovieCreatorImpl extends MovieCreator {
     final project = MovieProjectImpl(
       projectId: projectId,
       draftMovieManager: draftMovieManager,
+      fileManager: fileManager,
       movieDao: movieDao,
       slideShowCreator: slideShowCreator,
     );
@@ -47,6 +51,7 @@ class MovieCreatorImpl extends MovieCreator {
     final project = MovieProjectImpl(
       projectId: draftMovie.id,
       draftMovieManager: draftMovieManager,
+      fileManager: fileManager,
       movieDao: movieDao,
       slideShowCreator: slideShowCreator,
     );
@@ -60,6 +65,7 @@ class MovieCreatorImpl extends MovieCreator {
     await MovieProjectImpl(
       projectId: movie.id,
       draftMovieManager: draftMovieManager,
+      fileManager: fileManager,
       movieDao: movieDao,
       slideShowCreator: slideShowCreator,
     ).deleteProject();

--- a/lib/creator/slideshow_creator.dart
+++ b/lib/creator/slideshow_creator.dart
@@ -22,7 +22,7 @@ class SlideShow {
   final String mime;
   final Duration videoDuration;
 
-  SlideShow({
+  const SlideShow({
     required this.videoPath,
     required this.thumbPath,
     required this.mime,
@@ -55,8 +55,8 @@ class FFmpegSlideShowCreator extends SlideShowCreator {
     );
 
     return SlideShow(
-      videoPath: video.file.path,
-      thumbPath: thumbnail.file.path,
+      videoPath: video.path,
+      thumbPath: thumbnail.path,
       mime: video.mime,
       videoDuration: video.duration,
     );
@@ -120,7 +120,7 @@ class FFmpegSlideShowCreator extends SlideShowCreator {
     }
 
     return _Video(
-      file: File(videoPath),
+      path: videoPath,
       mime: videoCapability.mediaFormat.mime,
       duration: videoDuration,
     );
@@ -137,7 +137,7 @@ class FFmpegSlideShowCreator extends SlideShowCreator {
       _formatDurationForThumbnail(Duration.zero),
       "-noaccurate_seek",
       "-i",
-      video.file.path,
+      video.path,
       "-vframes",
       "1",
       "-y",
@@ -152,7 +152,7 @@ class FFmpegSlideShowCreator extends SlideShowCreator {
     }
     if (ReturnCode.isSuccess(await thumbSession.getReturnCode())) {
       Logger.d('Thumbnail is created $thumbPath');
-      return _Thumbnail(file: File(thumbPath));
+      return _Thumbnail(path: thumbPath);
     } else {
       Logger.e(
         'Failed to create thumbnail',
@@ -173,21 +173,21 @@ class FFmpegSlideShowCreator extends SlideShowCreator {
 }
 
 class _Video {
-  final File file;
+  final String path;
   final String mime;
   final Duration duration;
 
-  _Video({
-    required this.file,
+  const _Video({
+    required this.path,
     required this.mime,
     required this.duration,
   });
 }
 
 class _Thumbnail {
-  final File file;
+  final String path;
 
-  _Thumbnail({
-    required this.file,
+  const _Thumbnail({
+    required this.path,
   });
 }

--- a/lib/database.dart
+++ b/lib/database.dart
@@ -2,8 +2,10 @@
 
 import 'dart:async';
 import 'package:floor/floor.dart';
+import 'package:path/path.dart';
 import 'package:slidemix/draft/data/dao.dart';
 import 'package:slidemix/draft/data/entity.dart';
+import 'package:slidemix/logger.dart';
 import 'package:slidemix/movies/data/movie_dao.dart';
 import 'package:slidemix/movies/data/movie_entity.dart';
 import 'package:sqflite/sqflite.dart' as sqflite;
@@ -11,21 +13,36 @@ import 'package:sqflite/sqflite.dart' as sqflite;
 part 'database.g.dart';
 
 @Database(
-  version: 2,
+  version: 3,
   entities: [
     DraftMovieEntity,
     DraftMovieMediaEntity,
     MovieEntity,
   ],
 )
-// flutter packages pub run build_runner build
+// dart run build_runner build
 abstract class AppDatabase extends FloorDatabase {
   static Future<AppDatabase> build() async {
-    return $FloorAppDatabase.databaseBuilder('slidemix.db').addMigrations(
-      [
-        _MovieMimeMigration(startVersion: 1, endVersion: 2),
-      ],
-    ).build();
+    return $FloorAppDatabase
+        .databaseBuilder('slidemix.db')
+        .addMigrations(
+          [
+            _MovieMimeMigration(startVersion: 1, endVersion: 2),
+            _RelativeFilePathMigration(startVersion: 2, endVersion: 3),
+          ],
+        )
+        .addCallback(Callback(
+          onCreate: (_, version) {
+            Logger.d('AppDatabase created $version');
+          },
+          onOpen: (_) {
+            Logger.d('AppDatabase opened');
+          },
+          onUpgrade: (_, startVersion, endVersion) {
+            Logger.d('AppDatabase upgraded $startVersion $endVersion');
+          },
+        ))
+        .build();
   }
 
   DraftMovieDao get draftMovieDao;
@@ -35,14 +52,80 @@ abstract class AppDatabase extends FloorDatabase {
   MovieDao get movieDao;
 }
 
+class _BaseMigration extends Migration {
+  _BaseMigration(
+    Type type,
+    int startVersion,
+    int endVersion,
+    Future<void> Function(sqflite.Database database) migrate,
+  ) : super(startVersion, endVersion, (database) async {
+          try {
+            Logger.d('Start migration [$type] $startVersion $endVersion');
+            await migrate(database);
+            Logger.d('End migration [$type] $startVersion $endVersion');
+          } catch (ex, st) {
+            Logger.e(
+                'Failed to run migration [$type] $startVersion $endVersion', ex, st);
+            rethrow;
+          }
+        });
+}
+
 /// Add column mime to [MovieEntity]
-class _MovieMimeMigration extends Migration {
+class _MovieMimeMigration extends _BaseMigration {
   _MovieMimeMigration({
     required int startVersion,
     required int endVersion,
-  }) : super(startVersion, endVersion, (sqflite.Database database) async {
-          database.execute(
-            "ALTER TABLE ${MovieEntity.tableName} ADD `mime` TEXT NOT NULL DEFAULT 'video/avc'",
-          );
-        });
+  }) : super(
+          _MovieMimeMigration,
+          startVersion,
+          endVersion,
+          (database) async {
+            database.execute(
+              "ALTER TABLE ${MovieEntity.tableName} ADD `mime` TEXT NOT NULL DEFAULT 'video/avc'",
+            );
+          },
+        );
+}
+
+class _RelativeFilePathMigration extends _BaseMigration {
+  _RelativeFilePathMigration({
+    required int startVersion,
+    required int endVersion,
+  }) : super(
+          _RelativeFilePathMigration,
+          startVersion,
+          endVersion,
+          (database) async {
+            final draftCursor =
+                await database.queryCursor(DraftMovieMediaEntity.tableName);
+            while (await draftCursor.moveNext()) {
+              final draft = draftCursor.current;
+              Logger.e('draft $draft');
+
+              final id = draft['id'] as int?;
+              final path = basename(draft['path'] as String);
+
+              await database.rawUpdate(
+                'UPDATE ${DraftMovieMediaEntity.tableName} SET path = ? WHERE id = ?',
+                [path, id],
+              );
+            }
+
+            final movieCursor = await database.queryCursor(MovieEntity.tableName);
+            while (await movieCursor.moveNext()) {
+              final movie = movieCursor.current;
+              Logger.e('movie $movie');
+
+              final id = movie['id'] as int?;
+              final thumb = basename(movie['thumb'] as String);
+              final video = basename(movie['video'] as String);
+
+              await database.rawUpdate(
+                'UPDATE ${MovieEntity.tableName} SET thumb = ?, video = ? WHERE id = ?',
+                [thumb, video, id],
+              );
+            }
+          },
+        );
 }

--- a/lib/database.g.dart
+++ b/lib/database.g.dart
@@ -73,7 +73,7 @@ class _$AppDatabase extends AppDatabase {
     Callback? callback,
   ]) async {
     final databaseOptions = sqflite.OpenDatabaseOptions(
-      version: 2,
+      version: 3,
       onConfigure: (database) async {
         await database.execute('PRAGMA foreign_keys = ON');
         await callback?.onConfigure?.call(database);

--- a/lib/draft/draft_movie_manager.dart
+++ b/lib/draft/draft_movie_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:path/path.dart';
 import 'package:slidemix/creation/data/media.dart';
 import 'package:slidemix/draft/data/dao.dart';
 import 'package:slidemix/draft/data/draft_movie.dart';
@@ -36,7 +37,7 @@ class DraftMovieManagerImpl extends DraftMovieManager {
       final drafts = await draftMovieDao.getAll().first;
       for (final draft in drafts) {
         final media = (await draftMovieMediaDao.getAllByProject(draft.projectId).first)
-            .map((e) => Media(e.path))
+            .map((e) => Media(projectId: draft.projectId, path: e.path))
             .toList(growable: false);
         if (media.isEmpty) continue;
         result.add(
@@ -67,7 +68,7 @@ class DraftMovieManagerImpl extends DraftMovieManager {
     if (entity == null) return null;
 
     final media = (await draftMovieMediaDao.getAllByProject(projectId).first)
-        .map((e) => Media(e.path))
+        .map((e) => Media(projectId: projectId, path: e.path))
         .toList(growable: false);
     return DraftMovie(
       projectId: projectId,
@@ -97,7 +98,10 @@ class DraftMovieManagerImpl extends DraftMovieManager {
     // Add all media
     await draftMovieMediaDao.insertAll(
       media
-          .map((e) => DraftMovieMediaEntity(projectId: projectId, path: e.path))
+          .map((e) => DraftMovieMediaEntity(
+                projectId: projectId,
+                path: basename(e.path),
+              ))
           .toList(growable: false),
     );
   }

--- a/lib/extensions/iterable.dart
+++ b/lib/extensions/iterable.dart
@@ -6,6 +6,13 @@ extension IterableExtention<E> on Iterable<E> {
     return null;
   }
 
+  Iterable<R> mapIndexed<R>(R Function(E element, int index) convert) sync* {
+    var index = 0;
+    for (var element in this) {
+      yield convert(element, index++);
+    }
+  }
+
   E max(num Function(E element) predicate) {
     return reduce((curr, next) => predicate(curr) > predicate(next) ? curr : next);
   }

--- a/lib/file_manager.dart
+++ b/lib/file_manager.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:slidemix/creation/data/media.dart';
+import 'package:slidemix/draft/data/draft_movie.dart';
+import 'package:slidemix/logger.dart';
+import 'package:slidemix/movies/data/movie.dart';
+
+abstract interface class FileManager {
+  static FileManager of(BuildContext context) => RepositoryProvider.of(context);
+
+  Future<void> init();
+
+  Directory draftDir(int projectId);
+
+  Directory projectDir(int projectId);
+
+  File getThumb(Movie movie);
+
+  File getVideo(Movie movie);
+
+  File getThumbFromDraft(DraftMovie draft);
+
+  File getThumbFromDraftMedia(Media media);
+
+  /// imagePicker stores files in cacheDir, it has a specific TTL
+  /// Move files to dir with longer TTL to keep those files as long as we want to
+  Future<Iterable<Media>> copyToDraftDir(int projectId, Iterable<Media> media);
+
+  /// Normalize image names for FFmpeg
+  Future<Iterable<Media>> normalizeForCreation(int projectId, Iterable<Media> media);
+
+  Future<void> deleteProject(int projectId);
+
+  Future<void> deleteDraft(int projectId);
+}
+
+class FileManagerImpl implements FileManager {
+  late Directory _dir;
+
+  @override
+  Future<void> init() async {
+    _dir = await getApplicationDocumentsDirectory();
+  }
+
+  @override
+  Directory draftDir(int projectId) {
+    return Directory(_buildPath(_dir, 'project${projectId}_temp'));
+  }
+
+  @override
+  Directory projectDir(int projectId) {
+    return Directory(_buildPath(_dir, 'project$projectId'));
+  }
+
+  @override
+  File getThumb(Movie movie) {
+    if (movie.isDraft) {
+      return File(movie.thumb);
+    }
+
+    return File(_buildPath(projectDir(movie.id), movie.thumb));
+  }
+
+  @override
+  File getVideo(Movie movie) {
+    return File(_buildPath(projectDir(movie.id), movie.video));
+  }
+
+  @override
+  File getThumbFromDraft(DraftMovie draft) {
+    return getThumbFromDraftMedia(draft.media.first);
+  }
+
+  @override
+  File getThumbFromDraftMedia(Media media) {
+    return File(_buildPath(draftDir(media.projectId), media.path));
+  }
+
+  @override
+  Future<Iterable<Media>> copyToDraftDir(int projectId, Iterable<Media> media) async {
+    final result = <Media>[];
+
+    final dir = draftDir(projectId);
+    await dir.create();
+    for (final source in media) {
+      final newPath = await _moveFile(
+        source: source.path,
+        newPath: _buildPath(dir, source.path),
+      );
+      if (newPath == null) continue;
+      result.add(Media(
+        projectId: projectId,
+        // We care here only about relative path
+        path: basename(newPath),
+      ));
+    }
+
+    return result;
+  }
+
+  @override
+  Future<Iterable<Media>> normalizeForCreation(
+    int projectId,
+    Iterable<Media> media,
+  ) async {
+    final result = <Media>[];
+    final format = NumberFormat('000');
+
+    var index = 0;
+    final dir = draftDir(projectId);
+    for (final source in media) {
+      final newPath = await _moveFile(
+        source: _buildPath(dir, source.path),
+        newPath: _buildPath(dir, 'image${format.format(index++)}.jpg'),
+      );
+      if (newPath == null) continue;
+      result.add(Media(
+        projectId: projectId,
+        // We care here only about relative path
+        path: basename(newPath),
+      ));
+    }
+
+    return result;
+  }
+
+  @override
+  Future<void> deleteProject(int projectId) async {
+    await projectDir(projectId).delete(recursive: true);
+  }
+
+  @override
+  Future<void> deleteDraft(int projectId) async {
+    await draftDir(projectId).delete(recursive: true);
+  }
+
+  /// @return `null` when [source] can't be moved to the new path [newPath]
+  Future<String?> _moveFile({
+    required String source,
+    required String newPath,
+  }) async {
+    if (source == newPath) return newPath;
+
+    Logger.d('Move file from "$source" to "$newPath"');
+    final file = File(source);
+    try {
+      await file.rename(newPath);
+      Logger.d('Moved file to tempDir, $newPath');
+      return newPath;
+    } catch (ex, st) {
+      Logger.e('Failed to move file to tempDir, ${file.path}', ex, st);
+      try {
+        // If rename fails, copy the source file and then delete it
+        await file.copy(newPath);
+        file.delete().ignore();
+        Logger.d('Moved file to tempDir with fallback, $newPath');
+        return newPath;
+      } catch (ex, st) {
+        Logger.e('Failed to moved file to tempDir with fallback, $source', ex, st);
+        return source;
+      }
+    }
+  }
+
+  String _buildPath(Directory dir, String file) =>
+      "${dir.path}${Platform.pathSeparator}${basename(file)}";
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:slidemix/colors.dart';
 import 'package:slidemix/database.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/localizations.dart';
 import 'package:slidemix/logger.dart';
 import 'package:slidemix/navigation.dart';
@@ -15,6 +16,8 @@ void main() async {
 
   // DB
   final database = await AppDatabase.build();
+  final fileManager = FileManagerImpl();
+  await fileManager.init();
   final sharedPreferences = await SharedPreferences.getInstance();
 
   // Locale
@@ -28,6 +31,7 @@ void main() async {
 
   runApp(SlideMixApp(
     appDatabase: database,
+    fileManager: fileManager,
     sharedPreferences: sharedPreferences,
   ));
 }
@@ -36,11 +40,13 @@ class SlideMixApp extends StatelessWidget {
   static GlobalKey<NavigatorState> navigatorKey = GlobalKey();
 
   final AppDatabase appDatabase;
+  final FileManager fileManager;
   final SharedPreferences sharedPreferences;
 
   const SlideMixApp({
     super.key,
     required this.appDatabase,
+    required this.fileManager,
     required this.sharedPreferences,
   });
 
@@ -48,6 +54,7 @@ class SlideMixApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Setup(
       appDatabase: appDatabase,
+      fileManager: fileManager,
       sharedPreferences: sharedPreferences,
       child: MaterialApp(
         theme: _buildTheme(Brightness.light),

--- a/lib/movies/movies_bloc.dart
+++ b/lib/movies/movies_bloc.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:slidemix/draft/draft_movie_manager.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/localizations.dart';
 import 'package:slidemix/movies/data/movie_dao.dart';
 import 'package:slidemix/movies/data/movie_mapper.dart';
@@ -12,6 +13,7 @@ import 'package:slidemix/movies/data/movie.dart';
 
 class MoviesBloc extends Bloc<dynamic, MoviesState> {
   final DraftMovieManager _draftMovieManager;
+  final FileManager _fileManager;
   final MovieDao _movieDao;
 
   StreamSubscription<dynamic>? _draftSubscription;
@@ -19,8 +21,10 @@ class MoviesBloc extends Bloc<dynamic, MoviesState> {
 
   MoviesBloc({
     required DraftMovieManager draftMovieManager,
+    required FileManager fileManager,
     required MovieDao movieDao,
   })  : _draftMovieManager = draftMovieManager,
+        _fileManager = fileManager,
         _movieDao = movieDao,
         super(const MoviesState(<Movie>[])) {
     _subscribeToDBUpdates();
@@ -51,7 +55,7 @@ class MoviesBloc extends Bloc<dynamic, MoviesState> {
               id: draft.projectId,
               title: AppLocalizations.app()?.projectTitle(draft.projectId) ??
                   'project #${draft.projectId}',
-              thumb: draft.media.first.path,
+              thumb: _fileManager.getThumbFromDraft(draft).path,
               video: '',
               mime: '',
               duration: Duration.zero,

--- a/lib/movies/widget/movie_card.dart
+++ b/lib/movies/widget/movie_card.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:slidemix/colors.dart';
 import 'package:flutter/material.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/localizations.dart';
 import 'package:slidemix/movies/data/movie.dart';
 import 'package:timeago/timeago.dart' as timeago;
@@ -20,6 +19,8 @@ class MovieCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final fileManager = FileManager.of(context);
+
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         const padding = 8.0;
@@ -52,7 +53,7 @@ class MovieCard extends StatelessWidget {
                             width: imageSize,
                             height: imageSize,
                             child: Image.file(
-                              File(movie.thumb),
+                              fileManager.getThumb(movie),
                               fit: BoxFit.cover,
                               errorBuilder: (_, __, ___) => const SizedBox.shrink(),
                             ),
@@ -62,7 +63,7 @@ class MovieCard extends StatelessWidget {
                           width: imageSize,
                           height: imageSize,
                           child: Image.file(
-                            File(movie.thumb),
+                            fileManager.getThumb(movie),
                             fit: BoxFit.fitWidth,
                             errorBuilder: (_, __, ___) => const SizedBox.shrink(),
                           ),

--- a/lib/preview/widget/preview_player.dart
+++ b/lib/preview/widget/preview_player.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:slidemix/colors.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/localizations.dart';
 import 'package:slidemix/logger.dart';
 import 'package:slidemix/movies/data/movie.dart';
@@ -28,7 +27,7 @@ class _PreviewPlayerState extends State<PreviewPlayer> {
     super.initState();
 
     controller = VideoPlayerController.file(
-      File(widget.movie.video),
+      FileManager.of(context).getVideo(widget.movie),
     )
       ..initialize().then((_) {
         // Ensure the first frame is shown after the video is initialized, even before the play button has been pressed.
@@ -42,7 +41,7 @@ class _PreviewPlayerState extends State<PreviewPlayer> {
       ..addListener(() {
         if (controller?.value.hasError ?? false) {
           Logger.e(
-            'Failed to play video',
+            'Failed to play video ${widget.movie}',
             Exception(controller?.value.errorDescription),
           );
           final snackBar = SnackBar(

--- a/lib/preview/widget/preview_share_dialog.dart
+++ b/lib/preview/widget/preview_share_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/movies/data/movie.dart';
 
 class PreviewShareDialog {
@@ -11,7 +12,7 @@ class PreviewShareDialog {
     Share.shareXFiles(
       [
         XFile(
-          movie.video,
+          (FileManager.of(context).getVideo(movie)).path,
           name: movie.title,
           mimeType: movie.mime,
         ),

--- a/lib/setup.dart
+++ b/lib/setup.dart
@@ -8,18 +8,21 @@ import 'package:slidemix/creator/slideshow_creator.dart';
 import 'package:slidemix/creator/video_capability.dart';
 import 'package:slidemix/database.dart';
 import 'package:slidemix/draft/draft_movie_manager.dart';
+import 'package:slidemix/file_manager.dart';
 import 'package:slidemix/movies/movies_bloc.dart';
 import 'package:slidemix/preview/preview_bloc.dart';
 import 'package:slidemix/welcome/welcome_bloc.dart';
 
 class Setup extends StatelessWidget {
   final AppDatabase appDatabase;
+  final FileManager fileManager;
   final SharedPreferences sharedPreferences;
   final Widget child;
 
   const Setup({
     Key? key,
     required this.appDatabase,
+    required this.fileManager,
     required this.sharedPreferences,
     required this.child,
   }) : super(key: key);
@@ -34,12 +37,16 @@ class Setup extends StatelessWidget {
             draftMovieMediaDao: appDatabase.draftMovieMediaDao,
           ),
         ),
+        RepositoryProvider<FileManager>(
+          create: (_) => fileManager,
+        ),
         RepositoryProvider<MovieCreator>(
           create: (_) => MovieCreatorImpl(
             draftMovieManager: DraftMovieManagerImpl(
               draftMovieDao: appDatabase.draftMovieDao,
               draftMovieMediaDao: appDatabase.draftMovieMediaDao,
             ),
+            fileManager: fileManager,
             movieDao: appDatabase.movieDao,
             projectIdProvider: ProjectIdProviderImpl(
               sharedPreferences: sharedPreferences,
@@ -52,6 +59,7 @@ class Setup extends StatelessWidget {
       ],
       child: _BlocSetup(
         appDatabase: appDatabase,
+        fileManager: fileManager,
         child: child,
       ),
     );
@@ -60,11 +68,13 @@ class Setup extends StatelessWidget {
 
 class _BlocSetup extends StatelessWidget {
   final AppDatabase appDatabase;
+  final FileManager fileManager;
   final Widget child;
 
   const _BlocSetup({
     Key? key,
     required this.appDatabase,
+    required this.fileManager,
     required this.child,
   }) : super(key: key);
 
@@ -82,6 +92,7 @@ class _BlocSetup extends StatelessWidget {
         BlocProvider<MoviesBloc>(
           create: (_) => MoviesBloc(
             draftMovieManager: RepositoryProvider.of<DraftMovieManager>(context),
+            fileManager: fileManager,
             movieDao: appDatabase.movieDao,
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,10 +45,10 @@ dependencies:
   ffmpeg_kit_flutter_full_gpl: 5.1.0
 
   # https://pub.dev/packages/firebase_core
-  firebase_core: 2.13.0
+  firebase_core: 2.13.1
 
   # https://pub.dev/packages/firebase_crashlytics
-  firebase_crashlytics: 3.3.1
+  firebase_crashlytics: 3.3.2
 
   # https://pub.dev/packages/flutter_bloc
   flutter_bloc: 8.1.3
@@ -78,7 +78,7 @@ dependencies:
   path_provider: 2.0.15
 
   # https://pub.dev/packages/share_plus
-  share_plus: 7.0.1
+  share_plus: 7.0.2
 
   # https://pub.dev/packages/shared_preferences
   shared_preferences: 2.1.1


### PR DESCRIPTION
On iOS `getApplicationDocumentsDirectory` returns different path to the dir after each app run.
The PR contains changes to not store full path to files (draft media / thumbnail / video) in DB, but store only relative file's path and get the path in runtime.

DB migration is [here](https://github.com/feelsoftware/SlideMix/pull/2/commits/90b006fae1cbbb7ab8b4b46fc2beee3e4cacc871).